### PR TITLE
Add an option to hide hints after activation

### DIFF
--- a/options.html
+++ b/options.html
@@ -12,6 +12,9 @@
       li {
         margin: 0;
       }
+      fieldset {
+        margin-bottom: 1em;
+      }
     </style>
   </head>
   <body>
@@ -48,6 +51,26 @@
           <label for="mod_meta">
             <input type="radio" value="meta" name="mod" id="mod_meta" />
             Meta / Command
+          </label>
+        </li>
+      </ul>
+    </fieldset>
+
+    <fieldset>
+      <legend>After I hit a hint...</legend>
+      <ul>
+        <li>
+          <label for="deactivate_normal">
+            <input type="radio" value="normal" name="deactivate"
+              checked="true" id="deactivate_normal" />
+            keep the hints on screen so I can hit another one
+          </label>
+        </li>
+        <li>
+          <label for="deactivate_always">
+            <input type="radio" value="always" name="deactivate"
+              id="deactivate_always" />
+            hide the hints
           </label>
         </li>
       </ul>

--- a/options.js
+++ b/options.js
@@ -1,7 +1,8 @@
 var defaults = {
   activateModifier: 'ctrl',
   hintCharacters: 'fdjkghslrueicnxmowabzpt',
-  activateKey: 'm'
+  activateKey: 'm',
+  deactivateAfterHit: false
 };
 
 function getElements() {
@@ -12,6 +13,10 @@ function getElements() {
       ctrl: document.getElementById('mod_ctrl'),
       alt: document.getElementById('mod_alt'),
       meta: document.getElementById('mod_meta')
+    },
+    deactivate: {
+      normal: document.getElementById('deactivate_normal'),
+      always: document.getElementById('deactivate_always')
     }
   };
 }
@@ -28,7 +33,8 @@ function saveOptions() {
   var options = {
     hintCharacters: elements.hintCharacters.value || defaults.hintCharacters,
     activateKey: elements.activateKey.value || defaults.activateKey,
-    activateModifier: selectedModifier(elements.modifiers)
+    activateModifier: selectedModifier(elements.modifiers),
+    deactivateAfterHit: elements.deactivate.always.checked
   };
   chrome.storage.local.set(options, function() {
     showStatus('Options saved');
@@ -44,6 +50,8 @@ function restoreOptions() {
     elements.modifiers.ctrl.checked = mod === 'ctrl';
     elements.modifiers.alt.checked = mod === 'alt';
     elements.modifiers.meta.checked = mod === 'meta';
+    elements.deactivate.normal.checked = !options.deactivateAfterHit;
+    elements.deactivate.always.checked = options.deactivateAfterHit;
   });
 }
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -42,7 +42,7 @@ function Controller(view, hintGenerator, options) {
     return whenActive(function() {
       withCurrentHint(function(h){
         h.activate(e);
-        if (h.shouldFocus()) {
+        if (h.shouldFocus() || options.deactivateAfterHit) {
           deactivate();
         }
       });

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -6,7 +6,12 @@ var defaults = {
   activateModifier: "ctrl",
 
   // Activation key code
-  activateKey: 77
+  activateKey: 77,
+
+  // Whether the hints should always be hidden after hint activation
+  // (by default, they are only hidden after hitting something
+  // that should be focused rather than followed, i.e. a form input).
+  deactivateAfterHit: false
 };
 
 module.exports = defaults;

--- a/src/optionparser.js
+++ b/src/optionparser.js
@@ -6,7 +6,9 @@ function optionParser(raw) {
   return {
     activateKey: getActivateKey(raw_) || defaults.activateKey,
     activateModifier: getActivateModifier(raw_) || defaults.activateModifier,
-    hintCharacters: getHintCharacters(raw_) || defaults.hintCharacters
+    hintCharacters: getHintCharacters(raw_) || defaults.hintCharacters,
+    deactivateAfterHit: (typeof raw_.deactivateAfterHit === "boolean") ?
+        raw_.deactivateAfterHit : defaults.deactivateAfterHit
   };
 }
 


### PR DESCRIPTION
Thank you for making YAHE, it’s nice.

I have realized that YAHE would work better for me if it always cleared the hints after I hit one. This is most obvious on SPA-style pages like GitHub, where following a link does not result in a page reload. More generally, I seldom want to open several hints in a row.

Therefore, this pull request adds a straightforward option to deactivate hints after one is activated.
